### PR TITLE
Support newer GHC versions by providing a MonadFail instance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .cabal-sandbox
 cabal.sandbox.config
 dist/
+dist-*/
+*.code-workspace
+.vscode/

--- a/xml-extractors.cabal
+++ b/xml-extractors.cabal
@@ -1,5 +1,5 @@
 name:                xml-extractors
-version:             0.4.0.2
+version:             0.4.0.3
 synopsis:            Extension to the xml package to extract data from parsed xml
 description:
   This library provides functions to simplify extraction of data from


### PR DESCRIPTION
__Problem__:
```shell
Building library for xml-extractors-0.4.0.2..
[1 of 5] Compiling Text.XML.Light.Extractors.Extra ( src/Text/XML/Light/Extractors/Extra.hs, dist/build/Text/XML/Light/Extractors/Extra.o )
[2 of 5] Compiling Text.XML.Light.Extractors.Internal.Result ( src/Text/XML/Light/Extractors/Internal/Result.hs, dist/build/Text/XML/Light/Extractors/Internal/Result.o )

src/Text/XML/Light/Extractors/Internal/Result.hs:120:3: error:
    ‘fail’ is not a (visible) method of class ‘Monad’
    |
120 |   fail msg = ResultT $ return $ Fail (strMsg msg)
    |   ^^^^
cabal: Failed to build xml-extractors-0.4.0.2. See the build log above for details.

$ cabal --version
cabal-install version 3.2.0.0
compiled using version 3.2.0.0 of the Cabal library 
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 8.8.4
```
__Solution:__
Add `MonadFail` instance as per:
https://wiki.haskell.org/MonadFail_Proposal#Adapting_old_code